### PR TITLE
ATM-8-get-jenkins-pipeline-to-initiate-based-on-github-action-hook-on-push

### DIFF
--- a/Jenkinsfile-gcloud
+++ b/Jenkinsfile-gcloud
@@ -52,7 +52,7 @@ pipeline {
                 echo "Establishing docker environment..."
                 sh 'which docker'
                 sh 'docker version'
-                sh "docker login --username=${DOCKERHUB_USERNAME} --password=${DOCKERHUB_PASSWORD}"
+                sh 'echo $DOCKERHUB_PASSWORD | docker login -u $DOCKERHUB_USERNAME --password-stdin'
             }
         }
         stage("Build Docker Image") {

--- a/Jenkinsfile-gcloud
+++ b/Jenkinsfile-gcloud
@@ -74,6 +74,10 @@ pipeline {
         }
     }
     post {
+        always {
+            sh 'gcloud auth revoke $SERVICE_ACCOUNT_EMAIL'
+            echo "Service account email revoked"
+        }
         success {
             echo "Job success!"
         }

--- a/Jenkinsfile-gcloud
+++ b/Jenkinsfile-gcloud
@@ -28,14 +28,13 @@ pipeline {
     stages {
         stage("GCloud Environment"){
             steps {
+                echo "Running Jenkins job as build #: ${BUILD_NUMBER} on ${NODE_NAME} agent"
                 sh 'gcloud version'
-                
                 withCredentials([file(credentialsId: 'gcloud-jenkins-service-account-key', variable: 'keyFile')]) {
                     // do something with the file, for instance 
                     sh 'gcloud auth activate-service-account --key-file=$keyFile --project=$PROJECT_ID'
                     sh "gcloud auth configure-docker ${LOCATION}-docker.pkg.dev"
                 }
-                    
                 sh 'gcloud info'
             }
         }
@@ -48,7 +47,6 @@ pipeline {
         }
         stage("Docker Environment") {
             steps {
-                // echo "Running a job as build #: ${BUILD_NUMBER} on ${NODE_NAME} agent"
                 echo "Establishing docker environment..."
                 sh 'which docker'
                 sh 'docker version'

--- a/Jenkinsfile-gcloud
+++ b/Jenkinsfile-gcloud
@@ -1,0 +1,89 @@
+def get_credential(credentialName) {
+    def v;
+    withCredentials([string(credentialsId: credentialName, variable: "someVarName")]) {
+        v = env.someVarName;
+    }
+    return v
+}
+
+def get_additional_build_args() {
+    return "--build-arg NEXT_PUBLIC_GMAPS_MAP_ID_LIGHT=" + get_credential("NEXT_PUBLIC_GMAPS_MAP_ID_LIGHT") + " --build-arg GMAPS_API_KEY=" + get_credential("GMAPS_API_KEY")
+}
+
+pipeline {
+    agent {
+        docker { image 'gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine' }
+        // label "docker-agent-1"
+    }
+    environment {
+    //     SERVICE_ACCOUNT_KEY=credentials('gcloud-jenkins-service-account-key')
+        DOCKERHUB_USERNAME=credentials('dockerhub-username')
+        DOCKERHUB_PASSWORD=credentials('dockerhub-password')
+        PROJECT_ID=credentials('where-atm-sg-project-id')
+        LOCATION="asia-southeast1"
+        REPO="where-atm-sg"
+        TAG="1.0.4"
+    }
+    stages {
+        stage("GCloud Environment"){
+            steps {
+                sh 'gcloud version'
+                
+                withCredentials([file(credentialsId: 'gcloud-jenkins-service-account-key', variable: 'keyFile')]) {
+                    // do something with the file, for instance 
+                    // sh 'cat $keyFile'
+                    sh 'gcloud auth activate-service-account --key-file=$keyFile --project=$PROJECT_ID'
+                    // sh "gcloud config set project ${PROJECT_ID}"
+                }
+                    
+                sh 'gcloud info'
+            }
+        }
+        stage("Git SCM Checkout"){
+            steps {
+                sh 'git --version'
+                git branch: 'ATM-8-get-jenkins-pipeline-to-initiate-based-on-github-action-hook-on-push', url: 'https://github.com/benjyongzh/where-atm-sg.git'
+                // sh 'cat $GIT_URL'
+            }
+        }
+        stage("Docker Environment") {
+            steps {
+                // echo "Running a job as build #: ${BUILD_NUMBER} on ${NODE_NAME} agent"
+                echo "Establishing docker environment..."
+                sh 'which docker'
+                sh 'docker version'
+                sh "docker login --username=${DOCKERHUB_USERNAME} --password=${DOCKERHUB_PASSWORD}"
+            }
+        }
+        stage("Build Docker Image") {
+            steps {
+                echo "Building the docker images on ${NODE_NAME} agent..."
+                sh "docker build " + get_additional_build_args() + " -t ${DOCKERHUB_USERNAME}/${REPO}:${TAG} -t ${LOCATION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/app:${TAG} ."
+            }
+        }
+        stage("Push Images") {
+            steps {
+                sh "docker push ${DOCKERHUB_USERNAME}/${REPO}:${TAG}"
+                sh "docker push ${LOCATION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/app:${TAG}"
+            }
+        }
+        stage("Run Container") {
+            steps {
+                sh "gcloud run deploy ${REPO} --image ${LOCATION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/app:${TAG}"
+            }
+        }
+    }
+    post {
+        success {
+            echo "Job success!"
+        }
+        failure {
+            echo "Job failed..."
+        }
+        cleanup {
+            echo "Cleaning the workspace..."
+            sh 'docker images -q -f dangling=true | xargs --no-run-if-empty docker rmi'
+            cleanWs()
+        }
+    }
+}

--- a/Jenkinsfile-gcloud
+++ b/Jenkinsfile-gcloud
@@ -68,7 +68,7 @@ pipeline {
         }
         stage("Run Container") {
             steps {
-                sh "gcloud run deploy ${REPO} --image ${LOCATION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/app:${TAG}"
+                sh "gcloud run deploy ${REPO} --image ${LOCATION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/app:${TAG} --allow-unauthenticated"
             }
         }
     }

--- a/Jenkinsfile-gcloud
+++ b/Jenkinsfile-gcloud
@@ -34,6 +34,7 @@ pipeline {
                     // do something with the file, for instance 
                     sh 'gcloud auth activate-service-account --key-file=$keyFile --project=$PROJECT_ID'
                     sh "gcloud auth configure-docker ${LOCATION}-docker.pkg.dev"
+                    sh "gcloud config set run/region ${LOCATION}"
                 }
                 sh 'gcloud info'
             }

--- a/Jenkinsfile-gcloud
+++ b/Jenkinsfile-gcloud
@@ -17,6 +17,7 @@ pipeline {
     }
     environment {
     //     SERVICE_ACCOUNT_KEY=credentials('gcloud-jenkins-service-account-key')
+        SERVICE_ACCOUNT_EMAIL="jenkins-service-account@resolute-clock-392803.iam.gserviceaccount.com"
         DOCKERHUB_USERNAME=credentials('dockerhub-username')
         DOCKERHUB_PASSWORD=credentials('dockerhub-password')
         PROJECT_ID=credentials('where-atm-sg-project-id')

--- a/Jenkinsfile-gcloud
+++ b/Jenkinsfile-gcloud
@@ -31,9 +31,8 @@ pipeline {
                 
                 withCredentials([file(credentialsId: 'gcloud-jenkins-service-account-key', variable: 'keyFile')]) {
                     // do something with the file, for instance 
-                    // sh 'cat $keyFile'
                     sh 'gcloud auth activate-service-account --key-file=$keyFile --project=$PROJECT_ID'
-                    // sh "gcloud config set project ${PROJECT_ID}"
+                    sh "gcloud auth configure-docker ${LOCATION}-docker.pkg.dev"
                 }
                     
                 sh 'gcloud info'

--- a/Jenkinsfile-gcloud
+++ b/Jenkinsfile-gcloud
@@ -69,6 +69,11 @@ pipeline {
         stage("Run Container") {
             steps {
                 sh "gcloud run deploy ${REPO} --image ${LOCATION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/app:${TAG} --allow-unauthenticated"
+                // sh '''
+                // gcloud run services add-iam-policy-binding ${REPO} \
+                // --member="allUsers" \
+                // --role="roles/run.invoker"
+                // '''
             }
         }
     }

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -52,6 +52,8 @@ steps:
       - "--allow-unauthenticated"
       - "--image"
       - "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/app:${_TAG}"
+      - "--region"
+      - "${_LOCATION}"
     # script: |
     #   gcloud run deploy ${_REPO_NAME} --image ${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/app:${_TAG} --allow-unauthenticated
     id: "deploy run"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ steps:
     args:
       - "build"
       - "-t"
-      - "gcr.io/$PROJECT_ID/$_SERVICE_NAME:$COMMIT_SHA"
+      - "gcr.io/${LOCATION}-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}:${_TAG}"
       - "."
   #push image to container registry
   - name: "gcr.io/cloudbuilders/docker"
@@ -22,3 +22,6 @@ steps:
       - "gcr.io/$PROJECT_ID/$_SERVICE_NAME:$COMMIT_SHA"
       - "--region"
       - "$_DEPLOY_REGION"
+substitutions:
+  _REPO_NAME: where-atm-sg
+  _TAG: 1.0.4

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -44,10 +44,11 @@ steps:
     waitFor: ["push-dockerhub"]
   #deploy image from artifact registry to cloud run
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    entrypoint: gcloud
     args:
-      - run
-      - deploy
-      - ${_REPO_NAME}
+      - "run"
+      - "deploy"
+      - "${_REPO_NAME}"
       - "--allow-unauthenticated"
       - "--image"
       - "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/app:${_TAG}"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,24 @@
+steps:
+  #build conntainer image
+  - name: "gcr.io/cloudbuilders/docker"
+    args:
+      - "build"
+      - "-t"
+      - "gcr.io/$PROJECT_ID/$_SERVICE_NAME:$COMMIT_SHA"
+      - "."
+  #push image to container registry
+  - name: "gcr.io/cloudbuilders/docker"
+    args:
+      - "push"
+      - "gcr.io/$PROJECT_ID/$_SERVICE_NAME:$COMMIT_SHA"
+  #deploy image to cloud run
+  - name: "gcr.io/google.com/cloudsdktool/cloud_Sdk"
+    entrypoint: gcloud
+    args:
+      - "run"
+      - "deploy"
+      - "$SERVICE_NAME"
+      - "--image"
+      - "gcr.io/$PROJECT_ID/$_SERVICE_NAME:$COMMIT_SHA"
+      - "--region"
+      - "$_DEPLOY_REGION"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,10 +3,11 @@ steps:
   - name: "gcr.io/cloud-builders/docker"
     # entrypoint: "bash"
     args:
-      # - "-c"
-      - "login"
-      - "--username=$$DOCKER_USERNAME"
-      - "--password=$$DOCKER_PASSWORD"
+      - "-c"
+      - "echo $$DOCKERHUB_PASSWORD | docker login -u $$DOCKERHUB_USERNAME --password-stdin"
+      # - "login"
+      # - "--username=$$DOCKER_USERNAME"
+      # - "--password=$$DOCKER_PASSWORD"
     secretEnv: ["DOCKER_USERNAME", "DOCKER_PASSWORD"]
     id: "login"
   #build container image for both dockerhub and google artifact registry

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,9 +5,9 @@ steps:
     args:
       [
         "-c",
-        "docker login --username=$$DOCKER_USERNAME --password=$$DOCKER-PASSWORD",
+        "docker login --username=$$DOCKER_USERNAME --password=$$DOCKER_PASSWORD",
       ]
-    secretEnv: ["DOCKER_USERNAME", "DOCKER-PASSWORD"]
+    secretEnv: ["DOCKER_USERNAME", "DOCKER_PASSWORD"]
     id: "login"
   #build container image for both dockerhub and google artifact registry
   - name: "gcr.io/cloud-builders/docker"
@@ -34,14 +34,18 @@ steps:
     waitFor: ["build"]
   #push container image to artifact registry
   - name: "gcr.io/cloud-builders/docker"
-    args: ["push", "$$DOCKER_USERNAME/${_REPO_NAME}:${_TAG}"]
+    args:
+      [
+        "push",
+        "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/app:${_TAG}",
+      ]
     secretEnv: ["DOCKER_USERNAME"]
     id: "push-artifact-reg"
     waitFor: ["build"]
   #deploy image from artifact registry to cloud run
   - name: "gcr.io/cloud-builders/gcloud"
     script: |
-      gcloud run deploy ${_REPO_NAME} --image ${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/app:${_TAG}
+      gcloud run deploy ${_REPO_NAME} --image ${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/app:${_TAG} --allow-unauthenticated
     id: "deploy run"
     waitFor: ["push-artifact-reg"]
 substitutions:
@@ -53,7 +57,7 @@ availableSecrets:
     - versionName: projects/$PROJECT_ID/secrets/dockerhub-username/versions/latest
       env: "DOCKER_USERNAME"
     - versionName: projects/$PROJECT_ID/secrets/dockerhub-password/versions/latest
-      env: "DOCKER-PASSWORD"
+      env: "DOCKER_PASSWORD"
     - versionName: projects/$PROJECT_ID/secrets/gmaps-api-key/versions/latest
       env: "GMAPS_API_KEY"
     - versionName: projects/$PROJECT_ID/secrets/gmaps-map-id/versions/latest

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -41,11 +41,18 @@ steps:
       - "docker push ${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/app:${_TAG}"
     secretEnv: ["DOCKER_USERNAME"]
     id: "push-artifact-reg"
-    waitFor: ["build"]
+    waitFor: ["push-dockerhub"]
   #deploy image from artifact registry to cloud run
-  - name: "gcr.io/cloud-builders/gcloud"
-    script: |
-      gcloud run deploy ${_REPO_NAME} --image ${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/app:${_TAG} --allow-unauthenticated
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    args:
+      - run
+      - deploy
+      - ${_REPO_NAME}
+      - "--allow-unauthenticated"
+      - "--image"
+      - "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/app:${_TAG}"
+    # script: |
+    #   gcloud run deploy ${_REPO_NAME} --image ${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/app:${_TAG} --allow-unauthenticated
     id: "deploy run"
     waitFor: ["push-artifact-reg"]
 substitutions:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,44 +1,45 @@
 steps:
   #login dockerhub account
   - name: "gcr.io/cloud-builders/docker"
-    entrypoint: "bash"
+    # entrypoint: "bash"
     args:
-      [
-        "-c",
-        "docker login --username=$$DOCKER_USERNAME --password=$$DOCKER_PASSWORD",
-      ]
+      # - "-c"
+      - "login"
+      - "--username=$$DOCKER_USERNAME"
+      - "--password=$$DOCKER_PASSWORD"
     secretEnv: ["DOCKER_USERNAME", "DOCKER_PASSWORD"]
     id: "login"
   #build container image for both dockerhub and google artifact registry
   - name: "gcr.io/cloud-builders/docker"
-    entrypoint: "bash"
+    # script: |
+    #   docker build --build-arg NEXT_PUBLIC_GMAPS_MAP_ID_LIGHT=$$GMAPS_MAP_ID --build-arg GMAPS_API_KEY=$$GMAPS_API_KEY -t $$DOCKER_USERNAME/${_REPO_NAME}:${_TAG} -t ${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/app:${_TAG} .
+    # entrypoint: "bash"
     args:
-      [
-        "-c",
-        "docker build",
-        "--build-arg NEXT_PUBLIC_GMAPS_MAP_ID_LIGHT=$$GMAPS_MAP_ID",
-        "--build-arg GMAPS_API_KEY=$$GMAPS_API_KEY",
-        "-t $$DOCKER_USERNAME/${_REPO_NAME}:${_TAG}",
-        "-t ${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/app:${_TAG}",
-        ".",
-      ]
+      - "build"
+      - "--build-arg NEXT_PUBLIC_GMAPS_MAP_ID_LIGHT=$$GMAPS_MAP_ID"
+      - "--build-arg GMAPS_API_KEY=$$GMAPS_API_KEY"
+      - "-t $$DOCKER_USERNAME/${_REPO_NAME}:${_TAG}"
+      - "-t ${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/app:${_TAG}"
+      - "."
     secretEnv: ["DOCKER_USERNAME", "GMAPS_API_KEY", "GMAPS_MAP_ID"]
     id: "build"
     waitFor: ["login"]
   #push container image to dockerhub
   - name: "gcr.io/cloud-builders/docker"
-    entrypoint: "bash"
-    args: ["-c", "docker push", "$$DOCKER_USERNAME/${_REPO_NAME}:${_TAG}"]
+    # entrypoint: "bash"
+    args:
+      # - "-c"
+      # - "docker"
+      - "push"
+      - "$$DOCKER_USERNAME/${_REPO_NAME}:${_TAG}"
     secretEnv: ["DOCKER_USERNAME"]
     id: "push-dockerhub"
     waitFor: ["build"]
   #push container image to artifact registry
   - name: "gcr.io/cloud-builders/docker"
     args:
-      [
-        "push",
-        "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/app:${_TAG}",
-      ]
+      - "push"
+      - "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/app:${_TAG}"
     secretEnv: ["DOCKER_USERNAME"]
     id: "push-artifact-reg"
     waitFor: ["build"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -26,20 +26,19 @@ steps:
     waitFor: ["login"]
   #push container image to dockerhub
   - name: "gcr.io/cloud-builders/docker"
-    # entrypoint: "bash"
+    entrypoint: "bash"
     args:
-      # - "-c"
-      # - "docker"
-      - "push"
-      - "$$DOCKER_USERNAME/${_REPO_NAME}:${_TAG}"
+      - "-c"
+      - "docker push $$DOCKER_USERNAME/${_REPO_NAME}:${_TAG}"
     secretEnv: ["DOCKER_USERNAME"]
     id: "push-dockerhub"
     waitFor: ["build"]
   #push container image to artifact registry
   - name: "gcr.io/cloud-builders/docker"
+    entrypoint: "bash"
     args:
-      - "push"
-      - "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/app:${_TAG}"
+      - "-c"
+      - "docker push ${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/app:${_TAG}"
     secretEnv: ["DOCKER_USERNAME"]
     id: "push-artifact-reg"
     waitFor: ["build"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,7 @@
 steps:
   #login dockerhub account
   - name: "gcr.io/cloud-builders/docker"
-    # entrypoint: "bash"
+    entrypoint: "bash"
     args:
       - "-c"
       - "echo $$DOCKERHUB_PASSWORD | docker login -u $$DOCKERHUB_USERNAME --password-stdin"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,27 +1,60 @@
 steps:
-  #build conntainer image
-  - name: "gcr.io/cloudbuilders/docker"
+  #login dockerhub account
+  - name: "gcr.io/cloud-builders/docker"
+    entrypoint: "bash"
     args:
-      - "build"
-      - "-t"
-      - "gcr.io/${LOCATION}-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}:${_TAG}"
-      - "."
-  #push image to container registry
-  - name: "gcr.io/cloudbuilders/docker"
+      [
+        "-c",
+        "docker login --username=$$DOCKER_USERNAME --password=$$DOCKER-PASSWORD",
+      ]
+    secretEnv: ["DOCKER_USERNAME", "DOCKER-PASSWORD"]
+    id: "login"
+  #build container image for both dockerhub and google artifact registry
+  - name: "gcr.io/cloud-builders/docker"
+    entrypoint: "bash"
     args:
-      - "push"
-      - "gcr.io/$PROJECT_ID/$_SERVICE_NAME:$COMMIT_SHA"
-  #deploy image to cloud run
-  - name: "gcr.io/google.com/cloudsdktool/cloud_Sdk"
-    entrypoint: gcloud
-    args:
-      - "run"
-      - "deploy"
-      - "$SERVICE_NAME"
-      - "--image"
-      - "gcr.io/$PROJECT_ID/$_SERVICE_NAME:$COMMIT_SHA"
-      - "--region"
-      - "$_DEPLOY_REGION"
+      [
+        "-c",
+        "docker build",
+        "--build-arg NEXT_PUBLIC_GMAPS_MAP_ID_LIGHT=$$GMAPS_MAP_ID",
+        "--build-arg GMAPS_API_KEY=$$GMAPS_API_KEY",
+        "-t $$DOCKER_USERNAME/${_REPO_NAME}:${_TAG}",
+        "-t ${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/app:${_TAG}",
+        ".",
+      ]
+    secretEnv: ["DOCKER_USERNAME", "GMAPS_API_KEY", "GMAPS_MAP_ID"]
+    id: "build"
+    waitFor: ["login"]
+  #push container image to dockerhub
+  - name: "gcr.io/cloud-builders/docker"
+    entrypoint: "bash"
+    args: ["-c", "docker push", "$$DOCKER_USERNAME/${_REPO_NAME}:${_TAG}"]
+    secretEnv: ["DOCKER_USERNAME"]
+    id: "push-dockerhub"
+    waitFor: ["build"]
+  #push container image to artifact registry
+  - name: "gcr.io/cloud-builders/docker"
+    args: ["push", "$$DOCKER_USERNAME/${_REPO_NAME}:${_TAG}"]
+    secretEnv: ["DOCKER_USERNAME"]
+    id: "push-artifact-reg"
+    waitFor: ["build"]
+  #deploy image from artifact registry to cloud run
+  - name: "gcr.io/cloud-builders/gcloud"
+    script: |
+      gcloud run deploy ${_REPO_NAME} --image ${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/app:${_TAG}
+    id: "deploy run"
+    waitFor: ["push-artifact-reg"]
 substitutions:
   _REPO_NAME: where-atm-sg
+  _LOCATION: asia-southeast1
   _TAG: 1.0.4
+availableSecrets:
+  secretManager:
+    - versionName: projects/$PROJECT_ID/secrets/dockerhub-username/versions/latest
+      env: "DOCKER_USERNAME"
+    - versionName: projects/$PROJECT_ID/secrets/dockerhub-password/versions/latest
+      env: "DOCKER-PASSWORD"
+    - versionName: projects/$PROJECT_ID/secrets/gmaps-api-key/versions/latest
+      env: "GMAPS_API_KEY"
+    - versionName: projects/$PROJECT_ID/secrets/gmaps-map-id/versions/latest
+      env: "GMAPS_MAP_ID"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,24 +4,23 @@ steps:
     entrypoint: "bash"
     args:
       - "-c"
-      - "echo $$DOCKERHUB_PASSWORD | docker login -u $$DOCKERHUB_USERNAME --password-stdin"
-      # - "login"
-      # - "--username=$$DOCKER_USERNAME"
-      # - "--password=$$DOCKER_PASSWORD"
+      # - "echo $$DOCKERHUB_PASSWORD | docker login -u $$DOCKERHUB_USERNAME --password-stdin"
+      - "docker login --username=$$DOCKER_USERNAME --password=$$DOCKER_PASSWORD"
     secretEnv: ["DOCKER_USERNAME", "DOCKER_PASSWORD"]
     id: "login"
   #build container image for both dockerhub and google artifact registry
   - name: "gcr.io/cloud-builders/docker"
     # script: |
     #   docker build --build-arg NEXT_PUBLIC_GMAPS_MAP_ID_LIGHT=$$GMAPS_MAP_ID --build-arg GMAPS_API_KEY=$$GMAPS_API_KEY -t $$DOCKER_USERNAME/${_REPO_NAME}:${_TAG} -t ${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/app:${_TAG} .
-    # entrypoint: "bash"
+    entrypoint: "bash"
     args:
-      - "build"
-      - "--build-arg NEXT_PUBLIC_GMAPS_MAP_ID_LIGHT=$$GMAPS_MAP_ID"
-      - "--build-arg GMAPS_API_KEY=$$GMAPS_API_KEY"
-      - "-t $$DOCKER_USERNAME/${_REPO_NAME}:${_TAG}"
-      - "-t ${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/app:${_TAG}"
-      - "."
+      - "-c"
+      - "docker build --build-arg NEXT_PUBLIC_GMAPS_MAP_ID_LIGHT=$$GMAPS_MAP_ID --build-arg GMAPS_API_KEY=$$GMAPS_API_KEY -t $$DOCKER_USERNAME/${_REPO_NAME}:${_TAG} -t ${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/app:${_TAG} ."
+      # - "--build-arg 'NEXT_PUBLIC_GMAPS_MAP_ID_LIGHT=$$GMAPS_MAP_ID'"
+      # - "--build-arg 'GMAPS_API_KEY=$$GMAPS_API_KEY'"
+      # - "-t $$DOCKER_USERNAME/${_REPO_NAME}:${_TAG}"
+      # - "-t ${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/app:${_TAG}"
+      # - "."
     secretEnv: ["DOCKER_USERNAME", "GMAPS_API_KEY", "GMAPS_MAP_ID"]
     id: "build"
     waitFor: ["login"]


### PR DESCRIPTION
gcloud build has CI/CD ready upon pushing to main branch.

"jenkinsfile-gcloud" is an alternative manually-activated pipeline without github webhook (but still pushes to dockerhub, gcloud artifact registry and deployment on cloud run), perhaps useful for development, while gcloud for production